### PR TITLE
modified dynamic binding to static binding

### DIFF
--- a/src/main/java/org/ea/FileEmbeddedDocumentExtractor.java
+++ b/src/main/java/org/ea/FileEmbeddedDocumentExtractor.java
@@ -29,7 +29,7 @@ public class FileEmbeddedDocumentExtractor implements EmbeddedDocumentExtractor 
     private static Detector detector;
 
     public FileEmbeddedDocumentExtractor(Detector detector) {
-        this.detector = detector;
+        FileEmbeddedDocumentExtractor.detector = detector;
     }
 
     public boolean shouldParseEmbedded(Metadata metadata) {


### PR DESCRIPTION
this.detector = detector showed warning.  since detector is private data member, static binding should be employed.